### PR TITLE
Use activationCommands instead of activationEvents in your package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,12 +3,14 @@
   "main": "./lib/toggle-invisibles",
   "version": "0.1.0",
   "description": "Toggles the display of invisible characters and/or the wrap guide",
-  "activationEvents": [
-    "toggle-invisibles:toggle",
-    "toggle-invisibles:toggleBoth",
-    "toggle-invisibles:toggleInvisibles",
-    "toggle-invisibles:toggleIndentGuide"
-  ],
+  "activationCommands": {
+    "atom-workspace": [
+      "toggle-invisibles:toggle",
+      "toggle-invisibles:toggleBoth",
+      "toggle-invisibles:toggleInvisibles",
+      "toggle-invisibles:toggleIndentGuide"
+    ]
+  },
   "repository": "https://github.com/lee-dohm/toggle-invisibles",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
`activationEvents` has been deprecated.

![image](https://cloud.githubusercontent.com/assets/5422/7765483/9633d084-005e-11e5-825d-5b09ebfc844f.png)
